### PR TITLE
Ensure the resource stream is closed after reading a word list.

### DIFF
--- a/src/main/java/org/kohsuke/randname/Dictionary.java
+++ b/src/main/java/org/kohsuke/randname/Dictionary.java
@@ -61,6 +61,7 @@ public class Dictionary {
         String line;
         while ((line=r.readLine())!=null)
             col.add(line);
+        r.close();
     }
 
     static final Dictionary INSTANCE = new Dictionary();


### PR DESCRIPTION
Android's strict mode otherwise throws a nasty warning upon usage.